### PR TITLE
Perhaps a naive fix for allowing objects in mapDispatchToProps?

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -99,7 +99,7 @@ function connect(mapPropsToRequestsToProps,
 
     const mapDispatchToProps = dispatch => (merge({
       dispatch,
-    }, isFunction(componentMapDispatchToProps) ? componentMapDispatchToProps(dispatch) : {}));
+    }, isFunction(componentMapDispatchToProps) ? componentMapDispatchToProps(dispatch) : componentMapDispatchToProps));
 
     return reduxConnect(mapStateToProps, mapDispatchToProps)(ReactReduxFetch);
   };

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -99,7 +99,9 @@ function connect(mapPropsToRequestsToProps,
 
     const mapDispatchToProps = dispatch => (merge({
       dispatch,
-    }, isFunction(componentMapDispatchToProps) ? componentMapDispatchToProps(dispatch) : componentMapDispatchToProps));
+    }, isFunction(componentMapDispatchToProps)
+      ? componentMapDispatchToProps(dispatch)
+      : componentMapDispatchToProps));
 
     return reduxConnect(mapStateToProps, mapDispatchToProps)(ReactReduxFetch);
   };


### PR DESCRIPTION
Closes #3 

I **think** this should fix the issue, since it now just passes down the object into the the ``connect`` HoC from ``react-redux``.