### PR TITLE
Move React-related dependencies to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,11 @@
   },
   "dependencies": {
     "lodash": "4.14.2",
-    "react": "15.3.1",
-    "react-redux": "4.4.5",
-    "redux": "3.6.0",
     "seamless-immutable": "6.1.1"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0",
+    "redux": "^2.0.0 || ^3.0.0",
+    "react-redux": "^4.0.0 || ^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "eslint-plugin-jsx-a11y": "2.2.2",
     "eslint-plugin-react": "6.3.0",
     "mocha": "3.0.2",
+    "react": "15.4.1",
+    "react-redux": "5.0.1",
+    "redux": "3.6.0",
     "rimraf": "2.5.4"
   },
   "dependencies": {


### PR DESCRIPTION
This allows consumers to determine which versions of the React-related libraries they want to use, instead of locking it in this package.

For example, ``react-redux`` has a new version out (https://github.com/reactjs/react-redux/releases/tag/v5.0.0) that boasts significant performance improvements. I'm already using that in my project, yet I can't take advantage of it, since ``react-redux-fetch`` is tied to ``v4.x``.