### PR TITLE
Stop pinning Lodash peer dep to exact 4.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "seamless-immutable": "^7.1.2"
   },
   "peerDependencies": {
-    "lodash": "4.14.2",
+    "lodash": "^4.17.4",
     "react": "^0.14.0 || ^15.0.0-0",
     "react-redux": "^4.0.0 || ^5.0.0",
     "redux": "^2.0.0 || ^3.0.0"


### PR DESCRIPTION
Adding this module to a new project is tricky because there is a newer version of Lodash out, but this project has a peer dependency on a specific older version. I can't find any issue where the newer version doesn't work. This PR removes the version-pin and syncs the two Lodash versions to the current release.

```└── UNMET PEER DEPENDENCY lodash@4.17.4
npm WARN react-redux-fetch@0.10.0 requires a peer of lodash@4.14.2 but none was installed.```